### PR TITLE
feat: add Error Tracker admin dashboard at /staff/error-tracker

### DIFF
--- a/src/app/staff/error-tracker/page.tsx
+++ b/src/app/staff/error-tracker/page.tsx
@@ -1,0 +1,667 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useSelector } from "react-redux"
+import { useRouter } from "next/navigation"
+import { BACKEND_BASE_URL } from "@/lib/config"
+import styles from "./styles/styles.module.css"
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type TopPath = { path: string; statusCode: number; count: number }
+
+type ErrorStats = {
+  total: number
+  fiveXX: number
+  fourXX: number
+  topPaths: TopPath[]
+}
+
+type ErrorLog = {
+  _id: string
+  timestamp: string
+  method: string
+  path: string
+  statusCode: number
+  errorMessage: string
+  stack?: string
+  userId?: string
+  userEmail?: string
+  ip?: string
+  userAgent?: string
+  requestBody?: Record<string, any>
+  responseTimeMs?: number
+  source?: string
+}
+
+type Filters = {
+  from: string
+  to: string
+  statusFilter: string
+  method: string
+  path: string
+  page: number
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const ALLOWED_ROLES = ["Admin", "IT Admin"]
+const AUTO_REFRESH_SECS = 60
+const STATUS_OPTIONS = ["", "5xx", "4xx", "500", "502", "403", "401", "404", "400", "408"]
+const METHOD_OPTIONS = ["", "GET", "POST", "PUT", "DELETE", "PATCH"]
+
+// ─── Utils ──────────────────────────────────────────────────────────────────
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function sevenDaysAgoISO(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  return d.toISOString().slice(0, 10)
+}
+
+function toISORange(date: string, isEnd = false): string {
+  return isEnd ? `${date}T23:59:59.999Z` : `${date}T00:00:00.000Z`
+}
+
+function formatTimestamp(ts: string): string {
+  const d = new Date(ts)
+  const day = d.getDate().toString().padStart(2, "0")
+  const month = d.toLocaleDateString("en-GB", { month: "short" })
+  const year = d.getFullYear()
+  const time = d.toTimeString().slice(0, 8)
+  return `${day} ${month} ${year} ${time}`
+}
+
+function formatDateRange(from: string, to: string): string {
+  if (!from || !to) return "—"
+  const fmt = (s: string) => {
+    const d = new Date(s)
+    return `${d.getDate()} ${d.toLocaleDateString("en-GB", { month: "short" })} ${d.getFullYear()}`
+  }
+  return `${fmt(from)} – ${fmt(to)}`
+}
+
+function daysBetween(from: string, to: string): number {
+  return (new Date(to).getTime() - new Date(from).getTime()) / 86_400_000
+}
+
+function truncate(s: string, n: number): string {
+  return s && s.length > n ? s.slice(0, n) + "…" : s ?? ""
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const el = document.createElement("textarea")
+    el.value = text
+    document.body.appendChild(el)
+    el.select()
+    document.execCommand("copy")
+    document.body.removeChild(el)
+  }
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const ErrorTrackerPage = () => {
+  const user = useSelector((state: any) => state.user.user)
+  const router = useRouter()
+
+  const defaultFrom = sevenDaysAgoISO()
+  const defaultTo = todayISO()
+
+  // Filter bar editing state
+  const [fromDate, setFromDate] = useState(defaultFrom)
+  const [toDate, setToDate] = useState(defaultTo)
+  const [statusFilter, setStatusFilter] = useState("")
+  const [methodFilter, setMethodFilter] = useState("")
+  const [pathFilter, setPathFilter] = useState("")
+  const [filterError, setFilterError] = useState("")
+
+  // Applied/active query filters
+  const [filters, setFilters] = useState<Filters>({
+    from: defaultFrom,
+    to: defaultTo,
+    statusFilter: "",
+    method: "",
+    path: "",
+    page: 1,
+  })
+
+  const [stats, setStats] = useState<ErrorStats | null>(null)
+  const [errors, setErrors] = useState<ErrorLog[]>([])
+  const [pagination, setPagination] = useState({ total: 0, page: 1, pages: 1 })
+  const [loading, setLoading] = useState(true)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+  const [selectedError, setSelectedError] = useState<ErrorLog | null>(null)
+  const [countdown, setCountdown] = useState(AUTO_REFRESH_SECS)
+  const [accessDenied, setAccessDenied] = useState(false)
+  const [copiedBlock, setCopiedBlock] = useState<string | null>(null)
+
+  // ─── Role guard ───────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!user?.role) return
+    if (!ALLOWED_ROLES.includes(user.role)) {
+      router.push("/staff/approvals")
+    }
+  }, [user?.role, router])
+
+  // ─── API helpers ─────────────────────────────────────────────────────────
+
+  const apiFetch = useCallback(
+    async (endpoint: string, params: Record<string, string | number>) => {
+      const url = new URL(`${BACKEND_BASE_URL}/${endpoint}`)
+      Object.entries(params).forEach(([k, v]) => {
+        if (v !== "" && v !== undefined) url.searchParams.set(k, String(v))
+      })
+      const res = await fetch(url.toString(), {
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      })
+      if (res.status === 401 || res.status === 403) {
+        setAccessDenied(true)
+        throw new Error("ACCESS_DENIED")
+      }
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`)
+      return res.json()
+    },
+    []
+  )
+
+  const fetchAll = useCallback(
+    async (f: Filters) => {
+      setLoading(true)
+      try {
+        const fromISO = toISORange(f.from)
+        const toISO = toISORange(f.to, true)
+        const [statsData, errorsData] = await Promise.all([
+          apiFetch("error-dashboard/api/stats", { from: fromISO, to: toISO }),
+          apiFetch("error-dashboard/api/errors", {
+            from: fromISO,
+            to: toISO,
+            statusFilter: f.statusFilter,
+            method: f.method,
+            path: f.path,
+            page: f.page,
+            limit: 25,
+          }),
+        ])
+        setStats(statsData as ErrorStats)
+        setErrors((errorsData as any).errors ?? [])
+        setPagination({
+          total: (errorsData as any).total ?? 0,
+          page: (errorsData as any).page ?? 1,
+          pages: (errorsData as any).pages ?? 1,
+        })
+      } catch (err: any) {
+        if (err.message !== "ACCESS_DENIED") console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [apiFetch]
+  )
+
+  const fetchErrorDetail = useCallback(
+    async (id: string) => {
+      setLoadingDetail(true)
+      try {
+        const detail = await apiFetch(`error-dashboard/api/errors/${id}`, {})
+        setSelectedError(detail as ErrorLog)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoadingDetail(false)
+      }
+    },
+    [apiFetch]
+  )
+
+  // ─── Data loading on filter changes ──────────────────────────────────────
+
+  useEffect(() => {
+    fetchAll(filters)
+  }, [filters, fetchAll])
+
+  // ─── Auto-refresh countdown ───────────────────────────────────────────────
+
+  const filtersRef = useRef(filters)
+  filtersRef.current = filters
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          fetchAll(filtersRef.current)
+          return AUTO_REFRESH_SECS
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [fetchAll])
+
+  useEffect(() => {
+    setCountdown(AUTO_REFRESH_SECS)
+  }, [filters])
+
+  // ─── Escape key handler ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSelectedError(null)
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [])
+
+  // ─── Event handlers ───────────────────────────────────────────────────────
+
+  const handleApply = () => {
+    setFilterError("")
+    if (new Date(fromDate) > new Date(toDate)) {
+      setFilterError("'From' date must be before 'To' date.")
+      return
+    }
+    if (daysBetween(fromDate, toDate) > 30) {
+      setFilterError("Date range cannot exceed 30 days.")
+      return
+    }
+    setFilters({ from: fromDate, to: toDate, statusFilter, method: methodFilter, path: pathFilter, page: 1 })
+  }
+
+  const handleReset = () => {
+    setFromDate(defaultFrom)
+    setToDate(defaultTo)
+    setStatusFilter("")
+    setMethodFilter("")
+    setPathFilter("")
+    setFilterError("")
+    setFilters({ from: defaultFrom, to: defaultTo, statusFilter: "", method: "", path: "", page: 1 })
+  }
+
+  const handlePageChange = (p: number) => {
+    setFilters((prev) => ({ ...prev, page: p }))
+  }
+
+  const handleRowClick = (error: ErrorLog) => {
+    setSelectedError(error)
+    fetchErrorDetail(error._id)
+  }
+
+  const handleCopy = async (text: string, blockId: string) => {
+    await copyToClipboard(text)
+    setCopiedBlock(blockId)
+    setTimeout(() => setCopiedBlock(null), 2000)
+  }
+
+  // ─── Render helpers ───────────────────────────────────────────────────────
+
+  const renderStatCards = () => (
+    <div className={styles.statCards}>
+      <div className={styles.statCard}>
+        <div className={styles.statLabel}>Total Errors</div>
+        <div className={styles.statValue}>{loading ? "—" : (stats?.total ?? 0)}</div>
+      </div>
+      <div className={`${styles.statCard} ${styles.statRed}`}>
+        <div className={styles.statLabel}>5xx Server Errors</div>
+        <div className={styles.statValue}>{loading ? "—" : (stats?.fiveXX ?? 0)}</div>
+      </div>
+      <div className={`${styles.statCard} ${styles.statOrange}`}>
+        <div className={styles.statLabel}>4xx Client Errors</div>
+        <div className={styles.statValue}>{loading ? "—" : (stats?.fourXX ?? 0)}</div>
+      </div>
+      <div className={`${styles.statCard} ${styles.statPurple}`}>
+        <div className={styles.statLabel}>Selected Period</div>
+        <div className={styles.statPeriod}>{formatDateRange(filters.from, filters.to)}</div>
+      </div>
+    </div>
+  )
+
+  const renderFiltersBar = () => (
+    <div className={styles.filtersBar}>
+      <div className={styles.filtersRow}>
+        <div className={styles.filterGroup}>
+          <label>From</label>
+          <input
+            type="date"
+            value={fromDate}
+            max={toDate}
+            onChange={(e) => setFromDate(e.target.value)}
+          />
+        </div>
+        <div className={styles.filterGroup}>
+          <label>To</label>
+          <input
+            type="date"
+            value={toDate}
+            min={fromDate}
+            max={todayISO()}
+            onChange={(e) => setToDate(e.target.value)}
+          />
+        </div>
+        <div className={styles.filterGroup}>
+          <label>Status</label>
+          <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
+            {STATUS_OPTIONS.map((o) => (
+              <option key={o} value={o}>{o || "All"}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.filterGroup}>
+          <label>Method</label>
+          <select value={methodFilter} onChange={(e) => setMethodFilter(e.target.value)}>
+            {METHOD_OPTIONS.map((o) => (
+              <option key={o} value={o}>{o || "All"}</option>
+            ))}
+          </select>
+        </div>
+        <div className={`${styles.filterGroup} ${styles.filterSearch}`}>
+          <label>Search</label>
+          <input
+            type="text"
+            placeholder="Path or error message..."
+            value={pathFilter}
+            onChange={(e) => setPathFilter(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleApply()}
+          />
+        </div>
+        <div className={styles.filterActions}>
+          <button className={styles.applyBtn} onClick={handleApply}>Apply</button>
+          <button className={styles.resetBtn} onClick={handleReset}>Reset</button>
+        </div>
+      </div>
+      {filterError && <p className={styles.filterError}>{filterError}</p>}
+    </div>
+  )
+
+  const renderTopPaths = () => {
+    if (!stats?.topPaths?.length) return null
+    return (
+      <div className={styles.section}>
+        <h3 className={styles.sectionTitle}>Top Error Endpoints</h3>
+        <div className={styles.topPathsGrid}>
+          {stats.topPaths.map((p, i) => (
+            <div
+              key={i}
+              className={`${styles.topPathCard} ${p.statusCode >= 500 ? styles.topPathRed : styles.topPathOrange}`}
+            >
+              <span className={styles.topPathBadge}>{p.statusCode}</span>
+              <span className={styles.topPathPath} title={p.path}>{p.path}</span>
+              <span className={styles.topPathCount}>{p.count}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const renderMethodBadge = (method: string) => {
+    const colorMap: Record<string, string> = {
+      GET: styles.methodGet,
+      POST: styles.methodPost,
+      PUT: styles.methodPut,
+      DELETE: styles.methodDelete,
+      PATCH: styles.methodPatch,
+    }
+    return (
+      <span className={`${styles.badge} ${colorMap[method] ?? styles.methodDefault}`}>
+        {method}
+      </span>
+    )
+  }
+
+  const renderStatusBadge = (code: number) => (
+    <span className={`${styles.badge} ${code >= 500 ? styles.statusRed : styles.statusOrange}`}>
+      {code}
+    </span>
+  )
+
+  const renderSkeleton = () => (
+    <div className={styles.skeletonWrapper}>
+      {[...Array(7)].map((_, i) => (
+        <div key={i} className={styles.skeletonRow}>
+          {[...Array(6)].map((__, j) => (
+            <div key={j} className={styles.skeletonCell} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+
+  const renderTable = () => (
+    <div className={styles.section}>
+      <h3 className={styles.sectionTitle}>Error Log</h3>
+      <div className={styles.tableWrapper}>
+        {loading ? (
+          renderSkeleton()
+        ) : errors.length === 0 ? (
+          <div className={styles.emptyState}>No errors in this period ✓</div>
+        ) : (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Method</th>
+                <th>Path</th>
+                <th>Status</th>
+                <th>Message</th>
+                <th>Response Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {errors.map((err) => (
+                <tr key={err._id} onClick={() => handleRowClick(err)} className={styles.tableRow}>
+                  <td className={styles.timestampCell}>{formatTimestamp(err.timestamp)}</td>
+                  <td>{renderMethodBadge(err.method)}</td>
+                  <td className={styles.pathCell} title={err.path}>{truncate(err.path, 50)}</td>
+                  <td>{renderStatusBadge(err.statusCode)}</td>
+                  <td className={styles.msgCell} title={err.errorMessage}>
+                    {truncate(err.errorMessage, 90)}
+                  </td>
+                  <td className={styles.rtCell}>
+                    {err.responseTimeMs != null ? `${err.responseTimeMs}ms` : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+
+  const renderPagination = () => {
+    if (!loading && pagination.total === 0) return null
+    const { page, pages, total } = pagination
+    const pageNums: number[] = []
+    const start = Math.max(1, page - 2)
+    const end = Math.min(pages, page + 2)
+    for (let i = start; i <= end; i++) pageNums.push(i)
+
+    return (
+      <div className={styles.pagination}>
+        <span className={styles.paginationInfo}>
+          Page {page} of {pages} ({total} total)
+        </span>
+        <div className={styles.paginationControls}>
+          <button disabled={page <= 1} onClick={() => handlePageChange(page - 1)}>
+            Prev
+          </button>
+          {start > 1 && (
+            <>
+              <button onClick={() => handlePageChange(1)}>1</button>
+              <span className={styles.paginationEllipsis}>…</span>
+            </>
+          )}
+          {pageNums.map((p) => (
+            <button
+              key={p}
+              className={p === page ? styles.activePage : undefined}
+              onClick={() => handlePageChange(p)}
+            >
+              {p}
+            </button>
+          ))}
+          {end < pages && (
+            <>
+              <span className={styles.paginationEllipsis}>…</span>
+              <button onClick={() => handlePageChange(pages)}>{pages}</button>
+            </>
+          )}
+          <button disabled={page >= pages} onClick={() => handlePageChange(page + 1)}>
+            Next
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const renderCodeBlock = (label: string, content: string, blockId: string) => (
+    <div className={styles.codeBlock}>
+      <div className={styles.codeBlockHeader}>
+        <span>{label}</span>
+        <button
+          className={styles.copyBtn}
+          onClick={() => handleCopy(content, blockId)}
+        >
+          {copiedBlock === blockId ? "Copied!" : "Copy"}
+        </button>
+      </div>
+      <pre className={styles.codeContent}>{content}</pre>
+    </div>
+  )
+
+  const renderDetailModal = () => {
+    if (!selectedError) return null
+    const err = selectedError
+    return (
+      <div className={styles.modalBackdrop} onClick={() => setSelectedError(null)}>
+        <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+          <div className={styles.modalHeader}>
+            <h3>Error Detail</h3>
+            <button className={styles.modalClose} onClick={() => setSelectedError(null)}>
+              ×
+            </button>
+          </div>
+          <div className={styles.modalBody}>
+            {loadingDetail && (
+              <div className={styles.modalLoadingBar}>
+                <div className={styles.modalLoadingProgress} />
+              </div>
+            )}
+            <div className={styles.detailGrid}>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>Timestamp</span>
+                <span className={styles.detailValue}>{formatTimestamp(err.timestamp)}</span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>Status Code</span>
+                <span className={styles.detailValue}>{renderStatusBadge(err.statusCode)}</span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>Response Time</span>
+                <span className={styles.detailValue}>
+                  {err.responseTimeMs != null ? `${err.responseTimeMs}ms` : "—"}
+                </span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>Source</span>
+                <span className={styles.detailValue}>{err.source ?? "—"}</span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>User Email</span>
+                <span className={styles.detailValue}>{err.userEmail ?? "—"}</span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>User ID</span>
+                <span className={`${styles.detailValue} ${styles.detailMono}`}>{err.userId ?? "—"}</span>
+              </div>
+              <div className={styles.detailItem}>
+                <span className={styles.detailLabel}>IP Address</span>
+                <span className={styles.detailValue}>{err.ip ?? "—"}</span>
+              </div>
+              <div className={`${styles.detailItem} ${styles.detailItemFull}`}>
+                <span className={styles.detailLabel}>User Agent</span>
+                <span className={`${styles.detailValue} ${styles.detailWrap}`}>{err.userAgent ?? "—"}</span>
+              </div>
+            </div>
+
+            {err.errorMessage && renderCodeBlock(
+              "Error Message",
+              err.errorMessage,
+              `msg-${err._id}`
+            )}
+            {err.stack && renderCodeBlock(
+              "Stack Trace",
+              err.stack,
+              `stack-${err._id}`
+            )}
+            {err.requestBody && renderCodeBlock(
+              "Request Body",
+              JSON.stringify(err.requestBody, null, 2),
+              `body-${err._id}`
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── Access denied state ──────────────────────────────────────────────────
+
+  if (accessDenied) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.accessDenied}>
+          <div className={styles.accessDeniedIcon}>⛔</div>
+          <h2>Access Denied</h2>
+          <p>You do not have permission to view this page.</p>
+          <button className={styles.applyBtn} onClick={() => router.push("/staff/approvals")}>
+            Go Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── Role loading state ───────────────────────────────────────────────────
+
+  if (!user?.role) {
+    return <div className={styles.container} />
+  }
+
+  if (!ALLOWED_ROLES.includes(user.role)) {
+    return <div className={styles.container} />
+  }
+
+  // ─── Main render ──────────────────────────────────────────────────────────
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.pageHeader}>
+        <h2>Error Tracker</h2>
+        <div className={styles.refreshBadge}>
+          Auto-refresh in{" "}
+          <span className={countdown <= 10 ? styles.countdownUrgent : styles.countdownNormal}>
+            {countdown}s
+          </span>
+        </div>
+      </div>
+
+      {renderStatCards()}
+      {renderFiltersBar()}
+      {!loading && renderTopPaths()}
+      {renderTable()}
+      {!loading && renderPagination()}
+      {renderDetailModal()}
+    </div>
+  )
+}
+
+export default ErrorTrackerPage

--- a/src/app/staff/error-tracker/styles/styles.module.css
+++ b/src/app/staff/error-tracker/styles/styles.module.css
@@ -1,0 +1,713 @@
+/* ─── Container ──────────────────────────────────────────────────────────── */
+
+.container {
+  width: 100%;
+  padding-bottom: 2rem;
+}
+
+/* ─── Page header ────────────────────────────────────────────────────────── */
+
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.pageHeader h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #64676b;
+  margin: 0;
+}
+
+.refreshBadge {
+  font-size: 0.8rem;
+  color: #878787;
+  background: #f6f6f6;
+  border: 1px solid #ced4da;
+  border-radius: 20px;
+  padding: 4px 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.countdownNormal {
+  font-weight: 700;
+  color: #e67509;
+}
+
+.countdownUrgent {
+  font-weight: 700;
+  color: #dc3545;
+}
+
+/* ─── Stat cards ─────────────────────────────────────────────────────────── */
+
+.statCards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.statCard {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border-left: 4px solid #dee2e6;
+}
+
+.statRed {
+  border-left-color: #dc3545;
+}
+
+.statOrange {
+  border-left-color: #e67509;
+}
+
+.statPurple {
+  border-left-color: #6f42c1;
+}
+
+.statLabel {
+  font-size: 0.72rem;
+  color: #878787;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.statValue {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #212529;
+  line-height: 1;
+}
+
+.statPeriod {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #6f42c1;
+  margin-top: 0.3rem;
+  line-height: 1.3;
+}
+
+/* ─── Filters bar ────────────────────────────────────────────────────────── */
+
+.filtersBar {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 1.25rem;
+}
+
+.filtersRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.filterGroup label {
+  font-size: 0.72rem;
+  color: gray;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.filterGroup input,
+.filterGroup select {
+  padding: 0.4rem 0.65rem;
+  border: 1px solid #ced4da;
+  border-radius: 5px;
+  font-size: 0.875rem;
+  background: #ffffff;
+  color: #212529;
+  transition: border-color 0.15s ease-in-out;
+  height: 36px;
+}
+
+.filterGroup input:focus,
+.filterGroup select:focus {
+  outline: none;
+  border-color: #e67509;
+  box-shadow: 0 0 0 2px rgba(230, 117, 9, 0.15);
+}
+
+.filterSearch {
+  flex: 1;
+  min-width: 200px;
+}
+
+.filterSearch input {
+  width: 100%;
+}
+
+.filterActions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.applyBtn {
+  padding: 0 1.1rem;
+  height: 36px;
+  background: #e67509;
+  color: #ffffff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background 0.15s ease-in-out;
+}
+
+.applyBtn:hover {
+  background: #d66700;
+}
+
+.resetBtn {
+  padding: 0 1.1rem;
+  height: 36px;
+  background: #ffffff;
+  color: #e67509;
+  border: 1px solid #e67509;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.15s ease-in-out;
+}
+
+.resetBtn:hover {
+  background: #fae3d0;
+}
+
+.filterError {
+  color: #dc3545;
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+/* ─── Section card ───────────────────────────────────────────────────────── */
+
+.section {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1.25rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 1rem;
+}
+
+.sectionTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64676b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+
+/* ─── Top paths grid ─────────────────────────────────────────────────────── */
+
+.topPathsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.topPathCard {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.875rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+.topPathRed {
+  background: #fff5f5;
+  border: 1px solid #f5c2c7;
+}
+
+.topPathOrange {
+  background: #fff8f0;
+  border: 1px solid #ffd39b;
+}
+
+.topPathBadge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.07);
+  flex-shrink: 0;
+  color: #495057;
+}
+
+.topPathPath {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #495057;
+  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+    "Roboto Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.topPathCount {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #212529;
+  flex-shrink: 0;
+}
+
+/* ─── Table ──────────────────────────────────────────────────────────────── */
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.table th {
+  text-align: left;
+  padding: 0.6rem 0.875rem;
+  background: #f8f9fa;
+  color: #64676b;
+  font-weight: 600;
+  border-bottom: 2px solid #dee2e6;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.table td {
+  padding: 0.65rem 0.875rem;
+  border-bottom: 1px solid #f0f0f0;
+  color: #495057;
+  vertical-align: middle;
+}
+
+.tableRow {
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.tableRow:hover {
+  background: #f8f9fa;
+}
+
+.tableRow:hover td {
+  color: #212529;
+}
+
+.timestampCell {
+  white-space: nowrap;
+  font-size: 0.8rem;
+  color: #64676b;
+}
+
+.pathCell {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+    "Roboto Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.msgCell {
+  max-width: 320px;
+  color: #64676b;
+  font-size: 0.82rem;
+}
+
+.rtCell {
+  white-space: nowrap;
+  font-size: 0.82rem;
+  color: #878787;
+}
+
+/* ─── Badges ─────────────────────────────────────────────────────────────── */
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.methodGet    { background: #cce5ff; color: #004085; }
+.methodPost   { background: #d4edda; color: #155724; }
+.methodPut    { background: #fff3cd; color: #856404; }
+.methodDelete { background: #f8d7da; color: #721c24; }
+.methodPatch  { background: #e2d9f3; color: #432874; }
+.methodDefault{ background: #e2e3e5; color: #383d41; }
+
+.statusRed    { background: #f8d7da; color: #721c24; }
+.statusOrange { background: #ffe5cc; color: #7d4200; }
+
+/* ─── Skeleton ───────────────────────────────────────────────────────────── */
+
+.skeletonWrapper {
+  padding: 0.25rem 0;
+}
+
+.skeletonRow {
+  display: grid;
+  grid-template-columns: 1.6fr 0.5fr 1.5fr 0.5fr 2fr 0.7fr;
+  gap: 0.75rem;
+  padding: 0.6rem 0.875rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.skeletonCell {
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e8e8e8 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ─── Empty state ────────────────────────────────────────────────────────── */
+
+.emptyState {
+  text-align: center;
+  padding: 3.5rem 2rem;
+  color: #29bd25;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* ─── Pagination ─────────────────────────────────────────────────────────── */
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 0.75rem 1.25rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  margin-top: 0.25rem;
+}
+
+.paginationInfo {
+  font-size: 0.82rem;
+  color: #64676b;
+}
+
+.paginationControls {
+  display: flex;
+  gap: 0.2rem;
+  align-items: center;
+}
+
+.paginationControls button {
+  min-width: 32px;
+  height: 32px;
+  padding: 0 0.5rem;
+  border: 1px solid #dee2e6;
+  border-radius: 5px;
+  background: #ffffff;
+  color: #495057;
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: all 0.12s ease-in-out;
+}
+
+.paginationControls button:hover:not(:disabled) {
+  background: #e67509;
+  color: #ffffff;
+  border-color: #e67509;
+}
+
+.paginationControls button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.activePage {
+  background: #e67509 !important;
+  color: #ffffff !important;
+  border-color: #e67509 !important;
+  font-weight: 600;
+}
+
+.paginationEllipsis {
+  color: #878787;
+  padding: 0 4px;
+  font-size: 0.82rem;
+}
+
+/* ─── Detail modal ───────────────────────────────────────────────────────── */
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  animation: backdropFadeIn 0.18s ease;
+}
+
+@keyframes backdropFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.modal {
+  background: #ffffff;
+  border-radius: 10px;
+  width: 100%;
+  max-width: 740px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  animation: modalSlideIn 0.22s ease;
+}
+
+@keyframes modalSlideIn {
+  from { transform: translateY(-16px); opacity: 0; }
+  to   { transform: translateY(0);     opacity: 1; }
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #dee2e6;
+  flex-shrink: 0;
+}
+
+.modalHeader h3 {
+  color: #64676b;
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.modalClose {
+  background: none;
+  border: none;
+  font-size: 1.6rem;
+  cursor: pointer;
+  color: #878787;
+  line-height: 1;
+  padding: 0 4px;
+  transition: color 0.12s;
+}
+
+.modalClose:hover {
+  color: #212529;
+}
+
+.modalBody {
+  overflow-y: auto;
+  padding: 1.25rem;
+  flex: 1;
+}
+
+.modalLoadingBar {
+  height: 3px;
+  background: #f0f0f0;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.modalLoadingProgress {
+  height: 100%;
+  background: #e67509;
+  border-radius: 2px;
+  animation: progressPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes progressPulse {
+  0%   { width: 0%;   opacity: 1; }
+  60%  { width: 85%;  opacity: 1; }
+  100% { width: 100%; opacity: 0; }
+}
+
+/* ─── Detail grid ────────────────────────────────────────────────────────── */
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.875rem 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.detailItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.detailItemFull {
+  grid-column: 1 / -1;
+}
+
+.detailLabel {
+  font-size: 0.68rem;
+  color: #878787;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.detailValue {
+  font-size: 0.875rem;
+  color: #212529;
+}
+
+.detailMono {
+  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+    "Roboto Mono", monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+.detailWrap {
+  word-break: break-all;
+  font-size: 0.8rem;
+  color: #64676b;
+}
+
+/* ─── Code blocks ────────────────────────────────────────────────────────── */
+
+.codeBlock {
+  margin-top: 1rem;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.codeBlockHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f8f9fa;
+  padding: 0.45rem 0.875rem;
+  border-bottom: 1px solid #dee2e6;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64676b;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.copyBtn {
+  background: none;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  padding: 2px 10px;
+  font-size: 0.72rem;
+  cursor: pointer;
+  color: #495057;
+  transition: all 0.12s ease;
+  text-transform: none;
+  font-weight: 400;
+}
+
+.copyBtn:hover {
+  background: #e67509;
+  color: #ffffff;
+  border-color: #e67509;
+}
+
+.codeContent {
+  padding: 0.875rem;
+  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+    "Roboto Mono", monospace;
+  font-size: 0.78rem;
+  color: #212529;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  max-height: 220px;
+  overflow-y: auto;
+  background: #ffffff;
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* ─── Access denied ──────────────────────────────────────────────────────── */
+
+.accessDenied {
+  text-align: center;
+  padding: 5rem 2rem;
+}
+
+.accessDeniedIcon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.accessDenied h2 {
+  color: #dc3545;
+  margin-bottom: 0.5rem;
+  font-size: 1.4rem;
+}
+
+.accessDenied p {
+  color: #878787;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .statCards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .statCards {
+    grid-template-columns: 1fr;
+  }
+
+  .detailGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pagination {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+}

--- a/src/app/staff/layout.js
+++ b/src/app/staff/layout.js
@@ -27,6 +27,7 @@ import styles from "./styles/styles.module.css"
 // CONSTANTS
 // -----------------------------------
 const ADMIN_ROLES = ["Admin", "HOD"]
+const ERROR_TRACKER_ROLES = ["Admin", "IT Admin"]
 
 const MENU_ITEMS = [
   { href: "/staff/approvals", label: "Registration Approvals" },
@@ -36,6 +37,7 @@ const MENU_ITEMS = [
   { href: "/staff/events", label: "Events" },
   { href: "/staff/forms", label: "Forms", adminOnly: true },
   { href: "/staff/userManagement", label: "Roles & User Management", adminOnly: true },
+  { href: "/staff/error-tracker", label: "Error Tracker", requiredRoles: ERROR_TRACKER_ROLES },
   { href: "/staff/settings", label: "Account Settings" },
 ]
 
@@ -77,8 +79,12 @@ const Layout = ({ children }) => {
   }, [user?.role])
 
   const filteredMenuItems = useMemo(() => {
-    return MENU_ITEMS.filter(item => !item.adminOnly || hasAdminPermissions)
-  }, [hasAdminPermissions])
+    return MENU_ITEMS.filter(item => {
+      if (item.adminOnly) return hasAdminPermissions
+      if (item.requiredRoles) return item.requiredRoles.includes(user?.role)
+      return true
+    })
+  }, [hasAdminPermissions, user?.role])
 
   const isActiveMenu = useCallback((menuLink) => {
     return menuLink === pathname


### PR DESCRIPTION
- New page accessible to Admin and IT Admin roles only
- Stat cards: Total, 5xx, 4xx errors and selected period
- Filters bar: date range (max 30 days), status, method, free-text search
- Top Error Endpoints grid showing up to 8 hotspot paths
- Paginated error table with method/status colour badges
- Error detail modal with code blocks and copy-to-clipboard
- Auto-refresh every 60s with visible countdown
- Loading skeleton, empty state, and access-denied handling
- Staff nav updated to show "Error Tracker" for Admin and IT Admin