### PR TITLE
Fix updateCode fallback in certificate extraction logic

### DIFF
--- a/src/app/contractor/dashboard/page.tsx
+++ b/src/app/contractor/dashboard/page.tsx
@@ -99,7 +99,7 @@ const extractCertificatesFromFormPages = (pages: any[], vendorID?: string): { ex
                                 expiryDate: entry.expiryDate,
                                 issueDate: entry.issueDate,
                                 url: entry.url || "",
-                                updateCode: field.updateCode || "",
+                                updateCode: entry.updateCode || field.updateCode || "",
                                 vendorID,
                             }
                             if (validity === "expiring") expiring.push(cert)


### PR DESCRIPTION
## Summary
Fixed a bug in the certificate extraction logic where the `updateCode` field was not being properly retrieved from the certificate entry object.

## Key Changes
- Updated the `updateCode` assignment in `extractCertificatesFromFormPages` to check `entry.updateCode` before falling back to `field.updateCode`
- This ensures that certificate-specific update codes are prioritized over field-level defaults

## Implementation Details
The change modifies the fallback chain for the `updateCode` property from:
- `field.updateCode || ""`

To:
- `entry.updateCode || field.updateCode || ""`

This allows the function to use the update code directly from the certificate entry if available, while maintaining backward compatibility by falling back to the field-level update code if the entry doesn't have one.

https://claude.ai/code/session_01KaFahR9fuTt35SLNzLePzv